### PR TITLE
fix(compiler,template): a partial's edit makes its parent stale

### DIFF
--- a/code/MiniTPL/Compiler.php
+++ b/code/MiniTPL/Compiler.php
@@ -27,6 +27,9 @@ class Compiler {
 	public $_global_variables = array();
 	public $_literals = array();
 
+	/** Every partial {include} pasted into the template being compiled */
+	public $_includes = array();
+
 	/** Auto-escape printed variables unless the context or a modifier says otherwise */
 	public $_escape = true;
 
@@ -53,6 +56,7 @@ class Compiler {
 	/** Compile template file into php code */
 	function compile($filename, $output_filename, $find_path, $nocache) {
 		$contents = $this->load_contents($filename);
+		$this->_includes = array();
 
 		foreach ($this->hooks[Hook::POSITION_PRE] as $hook) {
 			$contents = $hook->execute($filename, $contents);
@@ -66,6 +70,7 @@ class Compiler {
 					$cn = "<!-- " . $file . " -->";
 					$fn = call_user_func($find_path, $file);
 					if ($fn !== false) {
+						$this->_includes[] = $fn . $file;
 						$cn = $this->load_contents($fn . $file);
 					}
 
@@ -105,6 +110,41 @@ class Compiler {
 
 			foreach ($this->hooks[Hook::POSITION_POST] as $hook) {
 				$contents = $hook->execute($filename, $contents);
+			}
+
+			// WHAT WAS PASTED IN, so the loader can see a partial change.
+			//
+			// {include} is a compile-time paste and the compiled file used to
+			// say nothing about where its text came from, so Template::load
+			// compared one mtime - the parent's - and editing a partial left
+			// every parent that includes it looking current. A deploy that
+			// only touched a partial shipped the previous markup, and the only
+			// way out was deleting the cache by hand.
+			//
+			// The manifest goes inside a php block, so a compiled template
+			// still emits exactly the bytes it did before: a closing tag
+			// swallows the newline that follows it. A template with no
+			// includes is given one at all, so only the files that actually
+			// paste something change shape.
+			//
+			// Nested includes come along for free: the loop above re-scans
+			// after each substitution, so a partial's own {include} is
+			// resolved in a later pass and recorded here with the rest.
+			if (!empty($this->_includes)) {
+				$manifest = array();
+				foreach (array_unique($this->_includes) as $include) {
+					// A path holding "*/" would end the comment early and
+					// leave a compiled file that will not parse. Legal on
+					// unix, never seen, and cheaper to drop than to debug:
+					// the worst it costs is the old behaviour, for that one.
+					if (strpos($include, "*/") === false) {
+						$manifest[] = $include;
+					}
+				}
+
+				if (!empty($manifest)) {
+					$contents = $this->_code("/* minitpl:includes\n" . implode("\n", $manifest) . "\n*/") . $contents;
+				}
 			}
 
 			$this->_r_mkdir(dirname($output_filename));

--- a/code/MiniTPL/Template.php
+++ b/code/MiniTPL/Template.php
@@ -83,7 +83,7 @@ class Template {
 			$f_compiled = $this->_compile_path($path) . $filename;
 			if (file_exists($f_compiled)) {
 				$r = 1;
-				if (file_exists($f_original) && (filemtime($f_original) > filemtime($f_compiled))) {
+				if (file_exists($f_original) && $this->_is_stale($f_original, $f_compiled)) {
 					$r = $this->compile($f_original, $f_compiled);
 				}
 			} else {
@@ -98,6 +98,80 @@ class Template {
 
 		$this->source = $filename;
 		return (bool)$r;
+	}
+
+	/**
+	 * Whether a compiled template predates its own source, or any partial
+	 * that {include} pasted into it.
+	 *
+	 * The parent's mtime alone is not an answer. {include} is a compile-time
+	 * paste, so a partial's text lives inside the compiled file with nothing
+	 * in the parent to show for it - and comparing the two mtimes says
+	 * "current" however long ago the partial moved on. Compiler records what
+	 * it pasted; this reads that back and stats each one.
+	 */
+	function _is_stale($f_original, $f_compiled) {
+		$compiled_at = filemtime($f_compiled);
+		if (filemtime($f_original) > $compiled_at) {
+			return true;
+		}
+
+		foreach ($this->_compiled_includes($f_compiled) as $include) {
+			// A partial that has since been DELETED is not staleness. The
+			// compiled file still holds its text and still renders; the
+			// absence becomes an error the next time the parent itself
+			// changes, which is where it can be read and acted on.
+			if (file_exists($include) && filemtime($include) > $compiled_at) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * The partial paths Compiler wrote into the head of a compiled template.
+	 *
+	 * Read line by line rather than by a fixed number of bytes: the manifest
+	 * is as long as the template has includes, and a read that stopped short
+	 * would find no terminator, answer nothing, and quietly restore the very
+	 * behaviour this exists to remove. A file compiled before this shipped
+	 * has no manifest and answers nothing, which is correct - it is rewritten
+	 * the first time its own source changes.
+	 */
+	function _compiled_includes($f_compiled) {
+		$f = fopen($f_compiled, "r");
+		if ($f === false) {
+			return array();
+		}
+
+		$first = fgets($f);
+		if ($first === false || strpos($first, "minitpl:includes") === false) {
+			fclose($f);
+			return array();
+		}
+
+		$out = array();
+		while (true) {
+			$line = fgets($f);
+			if ($line === false) {
+				break;
+			}
+
+			$line = rtrim($line, "\r\n");
+			// The manifest closes with "*/" and the php tag on the same line.
+			if (substr($line, 0, 2) === "*/") {
+				break;
+			}
+
+			if ($line !== "") {
+				$out[] = $line;
+			}
+		}
+
+		fclose($f);
+
+		return $out;
 	}
 
 	/** Compile template */

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -94,6 +94,87 @@ final class TemplateTest extends TestCase
 	}
 
 	/**
+	 * Editing a partial makes its parent stale.
+	 *
+	 * {include} is a compile-time paste, so the partial's text ends up inside
+	 * the parent's compiled file with nothing in the parent to show for it.
+	 * Comparing the parent's mtime to the compiled file answers "current"
+	 * however long ago the partial moved on, and the page keeps rendering the
+	 * old text until somebody deletes the cache by hand.
+	 *
+	 * The templates are written by the test rather than taken from the
+	 * fixtures, because the assertion is about one file changing while the
+	 * other does not - and a fixture's mtime belongs to whoever checked the
+	 * tree out.
+	 */
+	public function testEditingAPartialRecompilesItsParent(): void
+	{
+		$dir = self::RUNTIME_COMPILE . 'includes/';
+		mkdir($dir, 0777, true);
+
+		file_put_contents($dir . 'partial.tpl', "first\n");
+		file_put_contents($dir . 'parent.tpl', "{include partial.tpl}\n");
+
+		$this->assertStringContainsString('first', $this->renderParent($dir));
+
+		// ONLY THE PARTIAL CHANGES. The parent is not touched, which is the
+		// whole point. The future mtime is deliberate: a filesystem with
+		// one-second stamps would otherwise write both files inside the same
+		// tick and the comparison would have nothing to see.
+		file_put_contents($dir . 'partial.tpl', "second\n");
+		touch($dir . 'partial.tpl', time() + 5);
+		clearstatcache();
+
+		$this->assertStringContainsString(
+			'second',
+			$this->renderParent($dir),
+			'a partial changed and its parent still rendered the text it was compiled with'
+		);
+	}
+
+	/**
+	 * A partial that is deleted does not make its parent stale.
+	 *
+	 * The compiled file still holds the partial's text and still renders.
+	 * Recompiling would replace it with an html comment, which is a worse
+	 * answer than the one already on disk; the absence surfaces the next time
+	 * the parent itself changes, where it can be read and acted on.
+	 */
+	public function testDeletingAPartialLeavesTheParentAlone(): void
+	{
+		$dir = self::RUNTIME_COMPILE . 'deleted/';
+		mkdir($dir, 0777, true);
+
+		file_put_contents($dir . 'partial.tpl', "first\n");
+		file_put_contents($dir . 'parent.tpl', "{include partial.tpl}\n");
+
+		$this->assertStringContainsString('first', $this->renderParent($dir));
+
+		unlink($dir . 'partial.tpl');
+		clearstatcache();
+
+		$this->assertStringContainsString('first', $this->renderParent($dir));
+	}
+
+	/**
+	 * Load and render parent.tpl from one of this test's own directories.
+	 *
+	 * A fresh Template each time: the staleness question is asked by load(),
+	 * and an instance that already holds a compiled filename would not ask it
+	 * again.
+	 */
+	private function renderParent(string $dir): string
+	{
+		$tpl = new Template();
+		$tpl->set_paths($dir);
+		$tpl->set_compile_location(self::COMPILE, false);
+
+		$this->assertTrue($tpl->load('parent.tpl'));
+
+		return $tpl->get();
+	}
+
+	/**
 	 * A compile is never visible half-written.
 	 *
 	 * The compiled template is executed with include(), so a reader that

--- a/tests/compiled/06_includes.tpl
+++ b/tests/compiled/06_includes.tpl
@@ -1,3 +1,6 @@
+<?php /* minitpl:includes
+tests/templates/05_constants.tpl
+*/?>
 <?php $_v=&$this->vars;?>
 #### 1.6. Includes
 


### PR DESCRIPTION
## The problem

`{include}` is a compile-time paste. `Compiler::compile()` resolves each partial through `$find_path`, reads it, and substitutes the text into the parent — and records **nothing** about what it pasted. The compiled file carries no list of its sources.

`Template::load()` then decides freshness from a single mtime, the parent's:

```php
if (file_exists($f_original) && (filemtime($f_original) > filemtime($f_compiled))) {
    $r = $this->compile($f_original, $f_compiled);
}
```

That is a question about a file which did not change. **Editing a partial leaves every parent that includes it looking current**, and the old markup keeps rendering until something touches the parent or somebody deletes the compile cache by hand.

Reproduce:

1. Render a page whose template has `{include partial.tpl}`.
2. Edit `partial.tpl`.
3. Render again — the change is absent.

In a real tree this bites hardest where partials are shared. In mobius, `rows/list.tpl` has eleven parents and the head/foot partials are in nearly every screen, so a one-line partial edit silently under-ships across the whole app. A deploy that only touches a partial ships the previous markup, and a cache on a persistent volume survives the restart that was meant to pick it up. The workaround was a manual `rm -rf` that a human has to remember.

## The fix

`Compiler` collects the paths it actually resolved and writes them into the head of the compiled file:

```php
<?php /* minitpl:includes
templates/partials/head.tpl
*/?>
```

Inside a php block, so **a compiled template still emits exactly the bytes it emitted before** — the closing tag swallows its own newline. A template with no includes is given no manifest at all, so only files that actually paste something change shape: one golden in `tests/compiled/`.

Nested includes come along for free — the substitution loop re-scans after each pass, so a partial's own `{include}` is resolved on a later pass and recorded with the rest.

`Template::load()` reads that list back and compares the compiled file against the newest of the parent and every partial.

## Decisions worth arguing with

- **Read line by line, not a fixed number of bytes.** The manifest is as long as the template has includes. A read that stopped short would find no terminator, answer nothing, and quietly restore the exact behaviour this removes.
- **A file compiled before this change has no manifest and answers nothing.** That is right: it is rewritten the first time its own source changes. No migration, no cache flush on upgrade.
- **A deleted partial is deliberately not staleness.** The compiled file still holds its text and still renders; recompiling would replace it with an html comment, which is a worse answer than the one already on disk. The absence surfaces the next time the parent changes, where it can be read and acted on.
- **A path containing the characters that close a block comment is dropped** from the manifest rather than written into it. Legal on unix, never seen, and a compiled file that will not parse is a bad way to find out.

## Not fixed here

When `$find_path` returns false the include still compiles to `<!-- name.tpl -->` — the region renders blank, with no error and no log line. Same eleven lines, different bug; happy to do it in a separate PR if you want it.

## Tests

Two new cases in `TemplateTest`, both writing their own templates so the assertion is about one file changing while the other does not:

- `testEditingAPartialRecompilesItsParent`
- `testDeletingAPartialLeavesTheParentAlone`

`phpunit`: **69 tests, 202 assertions, all passing** (67 before). The only golden that changed is `tests/compiled/06_includes.tpl`, which is the one fixture with an `{include}`.

`phpscript lint ./code/... tests/*.phpt` is unchanged from master. The `tests/*.phpt` matrix could not be verified here — the `path` repository symlink does not resolve on a Windows host, and it fails identically on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
